### PR TITLE
Save console logs as file and handle permissions

### DIFF
--- a/testcloud/cli.py
+++ b/testcloud/cli.py
@@ -573,7 +573,7 @@ def _remove_instance(args):
         sys.exit(1)
 
     try:
-        tc_instance.remove(autostop=args.force)
+        tc_instance.remove(autostop=args.force, keep_console_log=False)
     except TestcloudInstanceError as e:
         log.error(e)
         sys.exit(1)

--- a/testcloud/config.py
+++ b/testcloud/config.py
@@ -100,6 +100,10 @@ class ConfigData(object):
 
     __DATA_DIR = "/var/lib/testcloud"
 
+    # This must point to location where virtlogd is
+    # permitted by SELinux to search
+    CONSOLE_LOG_DIR = "/var/lib/testcloud"
+
     @property
     def DATA_DIR(self):
         return self.__DATA_DIR


### PR DESCRIPTION
Additional fixes on top of #7, as discussed there.

Tested with `tmt` from [PR 3511](https://github.com/teemtee/tmt/pull/3511/commits) checkouted at `fc86613` (that is _without_ the additinal experimentation introduced in `aa5e190` and `92b6ab2`)

Works for both:
`$ tmt run provision -v -h virtual -c system finish`
and 
`$ tmt run provision -v -h virtual -c session finish`

<br />

`workdir` has expected (inherited) label `user_tmp_t`:
```
$ ll -dZ /var/tmp/tmt/run-060/plans/example/provision/default-0
drwxr-xr-x. 1 lbrabec lbrabec unconfined_u:object_r:user_tmp_t:s0 22  1. dub 11.33 /var/tmp/tmt/run-060/plans/example/provision/default-0
```

<br />

Symlink is created in the `tmt`'s `workdir` with target located in `testcloud`'s `ConfigData.CONSOLE_LOG_DIR` (i.e. `/var/lib/testcloud`)
```
$ ll -Z /var/tmp/tmt/run-060/plans/example/provision/default-0/
total 4
lrwxrwxrwx. 1 lbrabec lbrabec unconfined_u:object_r:user_tmp_t:s0 67  1. dub 11.33 console.log -> /var/lib/testcloud/a9ce9e1b-52bb-4bd4-aff2-4c249f518d77-console.log
```

<br />

The real console log file has label `virt_log_t` and permissions to allow user `root` to `rw`
```
$ ll -Z /var/lib/testcloud/a9ce9e1b-52bb-4bd4-aff2-4c249f518d77-console.log
-rw-rw-r--+ 1 lbrabec lbrabec unconfined_u:object_r:virt_log_t:s0 98781  1. dub 11.33 /var/lib/testcloud/a9ce9e1b-52bb-4bd4-aff2-4c249f518d77-console.log

$ getfacl /var/lib/testcloud/a9ce9e1b-52bb-4bd4-aff2-4c249f518d77-console.log
...
user:root:rw-
...
```

<br />

And the real log file contains console log:
```
$ tail /var/lib/testcloud/a9ce9e1b-52bb-4bd4-aff2-4c249f518d77-console.log
[   10.292728] cloud-init[1057]: Cloud-init v. 24.2 running 'modules:config' at Tue, 01 Apr 2025 09:33:54 +0000. Up 10.26 seconds.
         Starting user-runtime-dir@0.servic…er Runtime Directory /run/user/0...
[  OK  ] Finished user-runtime-dir@0.servic…User Runtime Directory /run/user/0.
         Starting user@0.service - User Manager for UID 0...
[  OK  ] Finished cloud-config.service - Cloud-init: Config Stage.
         Starting cloud-final.service - Cloud-init: Final Stage...
[  OK  ] Started user@0.service - User Manager for UID 0.
[  OK  ] Started session-1.scope - Session 1 of User root.
[  OK  ] Started session-2.scope - Session 2 of User root.
[   10.580897] cloud-init[1119]: Cloud-init v. 24.2 running 'modules:final' at Tue, 01 Apr 2025 09:33:55 +0000. Up 10.55 seconds.
```