### PR TITLE
Make mac address generation optional

### DIFF
--- a/testcloud/domain_configuration.py
+++ b/testcloud/domain_configuration.py
@@ -325,6 +325,7 @@ class DomainConfiguration:
     system_architecture: Optional[ArchitectureConfiguration]
     storage_devices: list[StorageDeviceConfiguration]
     network_configuration: Optional[NetworkConfiguration]
+    network_devices: list[NetworkConfiguration]
     tpm_configuration: Optional[TPMConfiguration]
     virtiofs_configuration: list[VIRTIOFSConfiguration]
     iommu_configuration: Optional[IOMMUConfiguration]

--- a/testcloud/domain_configuration.py
+++ b/testcloud/domain_configuration.py
@@ -445,7 +445,7 @@ class DomainConfiguration:
             <devices>
                 <emulator>{emulator_path}</emulator>
                 {storage_devices}
-                {network_configuraton}
+                {network_configuration}
                 <serial type='pty'>
                     {serial_log_configuraton}
                     <target port='0'/>
@@ -475,7 +475,7 @@ class DomainConfiguration:
             system_architecture=self.system_architecture.generate(),
             emulator_path=self.get_emulator(),
             storage_devices=self.generate_storage_devices(),
-            network_configuraton=self.generate_network_devices(),
+            network_configuration=self.generate_network_devices(),
             serial_log_configuraton=self.generate_serial_log_conf(),
             tpm=self.tpm_configuration.generate() if self.tpm_configuration else "",
             virtiofs_head=self.generate_virtiofs_head() if self.virtiofs_configuration else "",

--- a/testcloud/util.py
+++ b/testcloud/util.py
@@ -104,16 +104,6 @@ def spawn_instance_port_file(instance_name):
         return port
 
 
-def generate_mac_address():
-    """Create a workable mac address for our instances."""
-
-    hex_mac = [0x52, 0x54, 0x00]  # These 3 are the prefix libvirt uses
-    hex_mac += [random.randint(0x00, 0xFF) for x in range(3)]
-    mac = ":".join(hex(x)[2:] for x in hex_mac)
-
-    return mac
-
-
 def verify_url(url: str) -> str:
     if not url:
         raise exceptions.TestcloudImageError


### PR DESCRIPTION
libvirt will generate a mac address if it's unspecified.

I also fixed a typo in a variable name and added a type hint to `network_devices`.