### PR TITLE
Add RISC-V support

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,7 +112,7 @@ the **virt-manager** tool.
 
 Instances can be created with a different architecture than the host architecture. You'll need to have a proper
 qemu binary installed for this to work (eg. qemu-system-aarch64-core for aarch64 on x86_64 on Fedora). Supported
-architectures in testcloud are: x86_64, aarch64, ppc64le, and s390x. Any combinations of these are supported.
+architectures in testcloud are: x86_64, aarch64, ppc64le, s390x, and riscv64. Any combinations of these are supported.
 
 Some examples:
 
@@ -129,6 +129,11 @@ $ testcloud create centos-stream --arch x86_64
 ```
 # Fedora Rawhide ppc64le on aarch64 (or any other)
 $ testcloud create fedora:rawhide --arch ppc64le
+```
+
+```
+# Debian riscv64 on x86_64 (or any other)
+$ testcloud create debian:13 --arch riscv64
 ```
 
 ### Starting, stopping, and removing an instance

--- a/testcloud/config.py
+++ b/testcloud/config.py
@@ -273,8 +273,8 @@ storage:
         "latest": "9",
     }
 
-    DEBIAN_RELEASE_MAP = {"10": "buster", "11": "bullseye", "12": "bookworm"}
-    DEBIAN_LATEST = "12"
+    DEBIAN_RELEASE_MAP = {"10": "buster", "11": "bullseye", "12": "bookworm", "13": "trixie"}
+    DEBIAN_LATEST = "13"
     DEBIAN_IMG_URL = "https://cloud.debian.org/images/cloud/%s/daily/latest/debian-%s-genericcloud-%s-daily.qcow2"
 
     UBUNTU_RELEASES_API = "https://api.launchpad.net/devel/ubuntu/series"

--- a/testcloud/distro_utils/debian.py
+++ b/testcloud/distro_utils/debian.py
@@ -13,7 +13,7 @@ config_data = config.get_config()
 
 
 def get_debian_image_url(version: str, arch: str) -> str:
-    arch_map = {"x86_64": "amd64", "aarch64": "arm64", "ppc64le": "ppc64el"}
+    arch_map = {"x86_64": "amd64", "aarch64": "arm64", "ppc64le": "ppc64el", "riscv64": "riscv64"}
 
     if arch not in arch_map:
         log.error("Requested architecture is not supported by testcloud for Debian.")

--- a/testcloud/distro_utils/fedora.py
+++ b/testcloud/distro_utils/fedora.py
@@ -152,6 +152,10 @@ def get_fedora_image_url(version: str, arch: str) -> str:
             raise exceptions.TestcloudImageError
         return str(url)
 
+    # RISC-V image not released
+    if arch == "riscv64":
+        return "https://dl.fedoraproject.org/pub/alt/risc-v/release/42/Cloud/riscv64/images/Fedora-Cloud-Base-Generic-42.20250911-2251ba41cdd3.riscv64.qcow2"
+
     try:
         releases = session.get("https://getfedora.org/releases.json").json()
     except (ConnectionError, requests.exceptions.JSONDecodeError):

--- a/testcloud/distro_utils/fedora.py
+++ b/testcloud/distro_utils/fedora.py
@@ -154,7 +154,19 @@ def get_fedora_image_url(version: str, arch: str) -> str:
 
     # RISC-V image not released
     if arch == "riscv64":
-        return "https://dl.fedoraproject.org/pub/alt/risc-v/release/42/Cloud/riscv64/images/Fedora-Cloud-Base-Generic-42.20250911-2251ba41cdd3.riscv64.qcow2"
+        images_url = "https://dl.fedoraproject.org/pub/alt/risc-v/release/%s/Cloud/riscv64/images/" % version
+        try:
+            response = session.get(images_url)
+            response.raise_for_status()
+        except Exception:
+            log.error("Couldn't fetch RISC-V image listing for Fedora %s" % version)
+            raise exceptions.TestcloudImageError
+        matches = re.findall(r'href="(Fedora-Cloud-Base-Generic-[^"]+\.riscv64\.qcow2)"', response.text)
+        if not matches:
+            log.error("No RISC-V Cloud Base image found for Fedora %s" % version)
+            raise exceptions.TestcloudImageError
+        matches.sort(reverse=True)
+        return images_url + matches[0]
 
     try:
         releases = session.get("https://getfedora.org/releases.json").json()

--- a/testcloud/domain_configuration.py
+++ b/testcloud/domain_configuration.py
@@ -155,6 +155,37 @@ class S390xArchitectureConfiguration(ArchitectureConfiguration):
         )
 
 
+class RISCV64ArchitectureConfiguration(ArchitectureConfiguration):
+    qemu = "qemu-system-riscv64"
+    arch = "riscv64"
+    model = "virt"
+
+    def __init__(self, kvm=True, uefi=True, model="virt") -> None:
+        self.kvm = kvm
+        self.uefi = uefi
+        self.model = model
+
+    def generate(self) -> str:
+        return """
+        <os>
+            <type arch='{arch}' machine='{model}'>hvm</type>
+            {uefi_loader}
+            <boot dev='hd'/>
+        </os>
+        {cpu}
+        <memballoon model='virtio'></memballoon>
+        """.format(
+            arch=self.arch,
+            model=self.model,
+            uefi_loader="<loader readonly='yes' type='pflash'>/usr/share/edk2/riscv/RISCV_VIRT_CODE.qcow2</loader>",
+            cpu=(
+                "<cpu mode='host-passthrough' check='none'/>"
+                if self.kvm
+                else "<cpu mode='custom' match='exact'><model>rva23s64</model></cpu>"
+            ),
+        )
+
+
 def storage_device_name_generator():
     prefix = "vd"
     for i in range(26):
@@ -529,6 +560,8 @@ def _get_default_domain_conf(
         domain_configuration.system_architecture = Ppc64leArchitectureConfiguration(kvm=kvm, uefi=False, model="pseries")
     elif desired_arch == "s390x":
         domain_configuration.system_architecture = S390xArchitectureConfiguration(kvm=kvm, uefi=False, model="s390-ccw-virtio")
+    elif desired_arch == "riscv64":
+        domain_configuration.system_architecture = RISCV64ArchitectureConfiguration(kvm=kvm, uefi=True, model="virt")
     else:
         raise TestcloudInstanceError("Unsupported arch")
 


### PR DESCRIPTION
Support booting riscv64 image

- Fedora: add RISC-V image link.
- Debian: add riscv64 to the arch map, add Debian 13 (Trixie) to the release map since Trixie is the first Debian release with official RISC-V support.
- Add `RISCV64ArchitectureConfiguration`
- Update README for riscv64.